### PR TITLE
Create test for no lazy load if only id is used in child resolver

### DIFF
--- a/test/graphql-lazyloader/createLazyLoadMiddleware.ts
+++ b/test/graphql-lazyloader/createLazyLoadMiddleware.ts
@@ -196,7 +196,7 @@ test('does not lazy load if resolver only accesses id', async (t) => {
     },
     resolvers: {
       Foo: {
-        name: (node: any) => {
+        description: (node: any) => {
           return `only depends on id ${node.id}`;
         },
       },
@@ -212,6 +212,7 @@ test('does not lazy load if resolver only accesses id', async (t) => {
       type Foo {
         id: ID!
         name: String!
+        description: String!
       }
 
       type Query {
@@ -228,7 +229,7 @@ test('does not lazy load if resolver only accesses id', async (t) => {
     {
       foo {
         id
-        name
+        description
       }
     }
   `);
@@ -236,7 +237,7 @@ test('does not lazy load if resolver only accesses id', async (t) => {
   t.deepEqual(response, {
     foo: {
       id: '1',
-      name: 'only depends on id 1',
+      description: 'only depends on id 1',
     },
   });
 


### PR DESCRIPTION
Refs Question 1 in #4.

This is similar to only requesting `attendees`. This also doesn't call `getEvent`. And this is the whole point of lazy loading the event data, right?
![image](https://user-images.githubusercontent.com/5037600/116042430-ae8cab80-a66e-11eb-9612-ad8929414480.png)
(from https://medium.com/paypal-tech/graphql-resolvers-best-practices-cd36fdbcef55)