### PR TITLE
Create test for handling null values

### DIFF
--- a/test/graphql-lazyloader/createLazyLoadMiddleware.ts
+++ b/test/graphql-lazyloader/createLazyLoadMiddleware.ts
@@ -324,3 +324,53 @@ test('batches multiple requests', async (t) => {
 
   t.is(lazyLoad.callCount, 1);
 });
+
+test('root is null if element does not exist', async (t) => {
+  const lazyLoad = sinon
+    .stub()
+    .returns(null);
+
+  const schema = createSchemaWithMiddleware({
+    lazyLoadMap: {
+      Foo: lazyLoad,
+    },
+    resolvers: {
+      Query: {
+        foo: () => {
+          return {
+            id: '1',
+          };
+        },
+      },
+    },
+    typeDefs: gql`
+      type Foo {
+        id: ID!
+        name: String!
+      }
+
+      type Query {
+        foo: Foo
+      }
+    `,
+  });
+
+  const graphqlServer = await createGraphqlServer({
+    schema,
+  });
+
+  const response = await request(graphqlServer.url, gql`
+    {
+      foo {
+        id
+        name
+      }
+    }
+  `);
+
+  t.deepEqual(response, {
+    foo: null,
+  });
+
+  await graphqlServer.stop();
+});


### PR DESCRIPTION
Refs Question 2 in #4.

This currently doesn't work and throws "Cannot return null for non-nullable field Foo.name.: {"response":{"errors":[{"message":"Cannot return null for non-nullable field Foo.name." because `Foo.name` is set to null instead setting `Foo` to null. 